### PR TITLE
Handle converting PHP objects to XML where all object values are XML node attributes

### DIFF
--- a/api_util.php
+++ b/api_util.php
@@ -182,13 +182,13 @@ class api_util
 
         $table = array();
         // get the header row                                                                                                        
-        $header = fgetcsv($fp, 10000, ',', '"');
+        $header = fgetcsv($fp, 0, ',', '"');
         if (is_null($header) || is_null($header[0])) {
             throw new exception ("Unable to determine header.  Is there garbage in the file?");
         }
 
         // get the rows                                                                                                              
-        while (($data = fgetcsv($fp, 10000, ',', '"')) !== false) {
+        while (($data = fgetcsv($fp, 0, ',', '"')) !== false) {
             $row = array();
             foreach ($header as $key => $value) {
                 $row[$value] = $data[$key];

--- a/api_util.php
+++ b/api_util.php
@@ -141,10 +141,10 @@ class api_util
                 }
 
                 $firstKey = array_shift(array_keys($value));
-                if (is_array($value[$firstKey]) || count($value) > 1 ) {
+                if ((array_key_exists($firstKey, $value) && is_array($value[$firstKey])) || count($value) > 1 ) {
                     $_xml = self::phpToXml($node, $value);
                 } else {
-                    $v = $value[$firstKey];
+                    $v = array_key_exists($firstKey, $value) ? $value[$firstKey] : null;
                     $_xml .= "<$node>" . htmlspecialchars($v) . "</$node>";
                 }
 


### PR DESCRIPTION
Elements of the $values array passed to api_util::phpToXml() which represent XML node attributes (as signified by a leading @ sign) are unset in the "collect any attributes" loop.  If _all_ the elements of the $values array represent node attributes, this behavior results in no elements remaining in $values after the attribute collection loop completes, and so subsequent uses of the first key from that (now empty) array cause "undefined index" errors.

We fix this by testing for the existence of $firstKey before using it.

**Steps to reproduce the problem:**
1. convert a PHP object to XML with only node attributes in the set of values, like this:

```
$xml = api_util::phpToXml('get_invoice', array(array('@key' => '235')));
```

**Expected behavior:**
A result like this:

```
<get_invoice  key="235" ></get_invoice>
```

**Actual behavior:**
PHP 'undefined index' errors
