### PR TITLE
Don't limit the length of CSV lines read by csvToPhp

### DIFF
--- a/api_util.php
+++ b/api_util.php
@@ -182,13 +182,13 @@ class api_util
 
         $table = array();
         // get the header row                                                                                                        
-        $header = fgetcsv($fp, 10000, ',', '"');
+        $header = fgetcsv($fp, 0, ',', '"');
         if (is_null($header) || is_null($header[0])) {
             throw new exception ("Unable to determine header.  Is there garbage in the file?");
         }
 
         // get the rows                                                                                                              
-        while (($data = fgetcsv($fp, 10000, ',', '"')) !== false) {
+        while (($data = fgetcsv($fp, 0, ',', '"')) !== false) {
             $row = array();
             foreach ($header as $key => $value) {
                 $row[$value] = $data[$key];


### PR DESCRIPTION
CSV lines returned from the 3.0 API are limited to 10,000 characters when they are read by api_util::csvToPhp().  This can result in broken results if the object being retrieved has more than 10,000 characters' worth of data on a single row -- for instance, if it is an object with a potentially large number of subobject records (such as an invoice with multiple line items).

We fix this by setting fgetcsv()'s character limit to 0, which means the maximum line length is unlimited.  
**NOTE:** Per the [PHP docs for fgetcsv](http://php.net/manual/en/function.fgetcsv.php), setting the character limit to 0 produces the desired result only in PHP >=5.1.0.  PHP 5.0 is so outdated that this seems perfectly safe to me, though.

**Steps to reproduce:**
1. Request an invoice from the 3.0 API, like this:

```
$invoice = api_post::read('arinvoice', 123, null, $session);
print_r($invoice);
```

...where invoice ID 123 has several line items (4 or more seems to reproduce the problem pretty reliably), and $session is a valid api_session object.

**Expected behavior:**
A result like this:

```
Array
(
    [RECORDNO] => 123
    [RECORDTYPE] => ri
    [RECORDID] => INV0063
    [STATE] => Draft
    [RAWSTATE] => D

...etc...

)
```

**Actual behavior:**
A big pile of PHP "undefined offset" notices, followed by a mangled invoice array, something like:

```
Array
(
    [RECORDNO] => eitem[2].EXCHANGE_RATE
    [RECORDTYPE] => ARINVOICEITEMS.arinvoiceitem[2].ALLOCATIONKEY
    [RECORDID] => ARINVOICEITEMS.arinvoiceitem[2].ALLOCATION
    [STATE] => ARINVOICEITEMS.arinvoiceitem[2].LINEITEM
    [RAWSTATE] => ARINVOICEITEMS.arinvoiceitem[2].LINE_NO
    [CUSTOMERID] => ARINVOICEITEMS.arinvoiceitem[2].CURRENCY
    [CUSTOMERNAME] => ARINVOICEITEMS.arinvoiceitem[2].BASECURR
    [TRX_ENTITYDUE] => ARINVOICEITEMS.arinvoiceitem[2].TOTALPAID

...etc...

)
```
